### PR TITLE
Adding Dockerfile for Nginx with HTTP/2 support

### DIFF
--- a/nginx-h2/Dockerfile
+++ b/nginx-h2/Dockerfile
@@ -1,0 +1,48 @@
+FROM ubuntu:14.04
+MAINTAINER Bluesoft Fire <devops@bluesoft.com.br>
+
+# Install dependencies
+RUN apt-get -y update
+RUN apt-get -y upgrade
+RUN apt-get -y install gcc g++ make patch wget libpcre3-dev zlib1g-dev libssl-dev
+
+# Download nginx
+RUN mkdir $HOME/src
+RUN wget -O $HOME/src/nginx-1.9.3.tar.gz http://nginx.org/download/nginx-1.9.3.tar.gz 
+RUN tar xzf $HOME/src/nginx-1.9.3.tar.gz -C $HOME/src/
+
+# Apply http2 patch
+RUN wget -O $HOME/src/nginx-1.9.3/patch.http2.txt http://nginx.org/patches/http2/patch.http2.txt
+RUN cd $HOME/src/nginx-1.9.3/ && patch -p1 < patch.http2.txt
+
+# Compile nginx
+RUN mkdir -p /usr/local/nginx
+RUN cd $HOME/src/nginx-1.9.3/ && ./configure --prefix=/usr/local/nginx/ --user=www-data --group=www-data --build=nginx-bsh2-1 --with-http_ssl_module --with-http_v2_module
+
+RUN cd $HOME/src/nginx-1.9.3/ && make
+RUN cd $HOME/src/nginx-1.9.3/ && make install
+
+# Generate ssl key and certificate
+RUN mkdir /usr/local/nginx/conf/ssl
+RUN openssl genrsa -out /usr/local/nginx/conf/ssl/h2-server.key 2048
+RUN openssl req -subj "/C=BR/ST=SP/L=São Paulo/O=Acme Inc/OU=DevOps" -new -key /usr/local/nginx/conf/ssl/h2-server.key -out /usr/local/nginx/conf/ssl/h2-server.csr
+RUN openssl x509 -req -days 365 -in /usr/local/nginx/conf/ssl/h2-server.csr -signkey /usr/local/nginx/conf/ssl/h2-server.key -out /usr/local/nginx/conf/ssl/h2-server.crt
+
+RUN rm /usr/local/nginx/conf/ssl/h2-server.csr
+RUN chown -R www-data:www-data /usr/local/nginx/conf/ssl
+RUN chmod 0400 /usr/local/nginx/conf/ssl/h2-server.key
+RUN chmod 0444 /usr/local/nginx/conf/ssl/h2-server.crt
+
+# Configure nginx
+COPY nginx.conf.docker /usr/local/nginx/conf/nginx.conf
+RUN mkdir -p /usr/local/nginx/html/
+
+# Remove downloaded files
+RUN rm -r $HOME/src/nginx-1.9.3
+RUN rm $HOME/src/nginx-1.9.3.tar.gz
+
+# Expose ports
+EXPOSE 443
+
+# Run nginx
+ENTRYPOINT [ "/usr/local/nginx/sbin/nginx", "-g", "daemon off;" ]

--- a/nginx-h2/README.md
+++ b/nginx-h2/README.md
@@ -1,0 +1,24 @@
+## Build Nginx with HTTP/2 support
+
+This repository contains a Dockerfile that compiles an Nginx installation with support for HTTP/2 enabled. We also provide a sample nginx.conf.
+The build we do in this Dockerfile will work for a single static website. You may need to change some ```configure``` options according to your needs.
+
+To make the Docker build, you may clone this repository and run the Docker commands as follows.
+
+```
+$ git clone 
+$ cd 
+$ docker build -t nginx-h2 .
+$ docker run -d -p 8443:443 -v /path/to/my/website/:/usr/local/nginx/html/ nginx-h2
+```
+
+Change ```/path/to/my/website/``` to the absolute path to your website.
+
+Access ```https://localhost:8443/``` through your browser and have fun!
+
+## Important
+
+The HTTP/2 patch for Nginx is still in alpha. You may want to test it before putting it into production. [Read their blog post for more info].
+
+[//]: #
+[Read their blog post for more info]: <https://www.nginx.com/blog/early-alpha-patch-http2/>

--- a/nginx-h2/nginx.conf.docker
+++ b/nginx-h2/nginx.conf.docker
@@ -1,0 +1,39 @@
+
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include mime.types;
+    default_type application/octet-stream;
+
+    sendfile on;
+    keepalive_timeout 65;
+
+    server {
+        listen 443 ssl http2 default_server;
+        server_name localhost;
+
+        ssl on;
+
+        ssl_certificate      ssl/h2-server.crt;
+        ssl_certificate_key  ssl/h2-server.key;
+
+        ssl_session_cache    shared:SSL:1m;
+        ssl_session_timeout  5m;
+
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+
+        # Leia para mais informações sobre as opções para ssl_ciphers: https://wiki.mozilla.org/Security/Server_Side_TLS
+        ssl_ciphers "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:ECDHE-RSA-DES-CBC3-SHA:ECDHE-ECDSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA";
+
+        ssl_prefer_server_ciphers  on;
+
+        location / {
+            root   html;
+            index  index.html index.htm;
+        }
+    }
+}


### PR DESCRIPTION
The Dockerfile downloads and compiles an Nginx installation with HTTP/2
support enabled. It also has a sample config file.